### PR TITLE
fix(generator): cast frame.LEN in min() so WS read compiles under MSVC

### DIFF
--- a/include/nodepp/generator.h
+++ b/include/nodepp/generator.h
@@ -765,7 +765,7 @@ namespace nodepp { namespace generator { namespace ws {
         
         coYield(1); len=0;
 
-        while ( frame.LEN > 0 ){ sz = min( sx, frame.LEN );
+        while ( frame.LEN > 0 ){ sz = min( sx, (ulong) frame.LEN );
         coWait( str->_read_( bf, sz, &len )==-2 );
 
         if( frame.MSK ){ for( ulong x=0; x<len; ++x ){


### PR DESCRIPTION
generator.h (WebSocket frame read) calls `min( sx, frame.LEN )`, mixing `ulong`
(sx) and `uchar_64` (frame.LEN). With the namespaced `min<T>` from #32, template
argument deduction fails on this mismatch under MSVC 2022 (/std:c++20), so the
WebSocket translation unit does not build on Windows.

One-line cast resolves it, matching the existing style elsewhere in this file
(e.g. the other min() call sites already cast their arguments):

    while ( frame.LEN > 0 ){ sz = min( sx, (ulong) frame.LEN );

Verified: with this cast, dev builds clean on MSVC 2022 x64 /std:c++20 /MT and
the #36 WebSocket connect path runs (see the #36 confirmation).
