### PR TITLE
tcp_t::listen() permanently stops accepting connections after one accept() error (Windows/IOCP)

### DIFF
--- a/include/nodepp/tcp.h
+++ b/include/nodepp/tcp.h
@@ -99,7 +99,7 @@ public:
             while( *enb > NODEPP_MAX_BATCH_SIZE ){ return 1; } int c=-1;
 
             if((c= sk._accept())==-2 ){ /*-----------------------------*/ return  0; }
-            if( c==-1 ){ self->onError.emit("Error while accepting TCP"); return -1; }
+            if( c==-1 ){ self->onError.emit("Error while accepting TCP"); return  0; }
             
             auto cli=socket_t(c); *enb += 1;
             /**/ cli.set_sockopt( self->obj->agent );


### PR DESCRIPTION
Repro (byte-for-byte, MSVC 2022 x64 /std:c++20 /O2 /MT, Windows 11, against
main @ 649b929): a bare http::server() handler that does nothing but write an
immediate 200 response (no read_body(), no chunked framing -- rules those out
as a cause). A client opens N sequential fresh TCP connections, one at a time,
each with a trivial GET and Connection: close.

    conn  0: ok
    conn  1: CONNECT FAILED / RECV RESET (WinError 10061 / 10054)
    conn  2..N: CONNECT FAILED: ConnectionRefusedError (WinError 10061)

Server log for the same run:

    [server] listening on http://127.0.0.1:18092
    [server] req path=/ping0
    [server] onError: Error while accepting TCP

The first accept-cycle error permanently tears down the listener. The listen
poll is the process's only outstanding task, so once it is removed the process
has nothing left to do and exits; the OS accept backlog then drains and refuses
all subsequent SYNs. This is deterministic and independent of connection
pacing: pacing only changes WHEN the first accept error lands (e.g. paced at
250ms it served conns 0-3, then died at the first error), never whether the
listener dies.

Root cause: tcp.h, listen()'s accept poll callback --

    if((c= sk._accept())==-2 ){ /*-----------------------------*/ return  0; }
    if( c==-1 ){ self->onError.emit("Error while accepting TCP"); return -1; }

(tcp.h:101-102 at 649b929.) Returning -1 from a process::poll callback removes
that poll task permanently. In windows/kernel.h the callback's result reaches
the dispatcher two ways -- the event lambda registered in poll_add
(kernel.h:238, `return clb(args...) >= 0 ? 1 : -1`) and, on the null-address
tick, invoker() itself -- and in both the -1 result triggers `remove(x)`
(invoker null-address path kernel.h:113; coroutine/address path kernel.h:134).
So a SINGLE accept() failure -- of any kind, transient or not -- permanently
kills the listener for the rest of the process's life, not just that one
connection attempt. (Note: the kernel.h invoker reordering between 50910bd3 and
649b929 -- checking KV_STATE_USED before callback()==-1 -- does not change this;
the -1 -> remove(x) path is unchanged.)

Diagnostic instrumentation (temporary, not part of this patch) on
windows/socket.h's socket_t::_accept() -- byte-identical at 50910bd3 and
649b929 -- shows what happens on the second accept cycle, immediately after the
first connection is torn down:

    [DIAG _accept/post] created tmp=264 wsaerr_after_create=0
    [DIAG _accept/post] AcceptEx fd=256 tmp=264 ret=0 wsaerr=997 (ERROR_IO_PENDING)
    [DIAG _accept/completion] tmp=264 fd=256 setsockopt_ret=0 wsaerr=0
    [server] req path=/ping0
    [DIAG _accept/post] created tmp=268 wsaerr_after_create=0
    [DIAG _accept/post] AcceptEx fd=256 tmp=268 ret=0 wsaerr=997 (ERROR_IO_PENDING)
    [DIAG _accept/completion] tmp=268 fd=256 setsockopt_ret=-1 wsaerr=10057
    [server] onError: Error while accepting TCP

wsaerr=10057 is WSAENOTCONN. At socket.h:637-640 the second AcceptEx is posted
correctly (pending, 997), but on the next poll tick its OVERLAPPED already reads
as complete and SO_UPDATE_ACCEPT_CONTEXT (socket.h:627) is attempted on a socket
that was never actually connected -- no second client had reached the server
yet. That premature/incorrect completion signal is a deeper issue and needs
someone who knows this codebase's IOCP dispatch (windows/kernel.h poll_add /
invoker completion routing) to fully root-cause; we have not traced it past
this point.

Regardless of that deeper cause, tcp.h's accept callback treating ANY accept()
failure as fatal to the whole listener is the actual crash multiplier and is
fixable independently and safely: an accept loop should never permanently die
because one accept cycle failed.

Proposed minimal fix (matches how the existing -2/pending case is already
handled -- log and retry, don't kill the task):

    if((c= sk._accept())==-2 ){ /*-----------------------------*/ return  0; }
    if( c==-1 ){ self->onError.emit("Error while accepting TCP"); return  0; }

Before/after, same repro at 649b929:

    BEFORE: process dies at the first accept error -- deterministic. Rapid-fire:
            1/15 served, then process exits. Paced (250ms): 4/15, then exits.
            Every connection after the first accept error is refused.

    AFTER:  process stays up through every accept error and the listener
            self-heals on the next poll tick. Paced sequential connections:
            15/15 (100ms), 59/60 (60ms). Under rapid-fire reconnects the listener
            survives and keeps serving but the deeper WSAENOTCONN premature-
            completion above still costs the single in-flight connection at each
            error (~11-13/15, ~46-48/60). This one-line change fixes the
            catastrophic listener death; it does not attempt to fix that deeper
            premature-completion.

Happy to open this as a PR to tcp.h with the one-line change above, plus the
bare-handler repro under test/, if useful.
